### PR TITLE
Fix hiding pagination

### DIFF
--- a/lib/components/github/Pagination.js
+++ b/lib/components/github/Pagination.js
@@ -15,7 +15,7 @@ export default class Pagination extends React.Component {
 
   render () {
     const { pagination } = this.props
-    if (!pagination) return ''
+    if (!pagination) return null
 
     const iconMap = {
       first: 'fa fa-fast-backward',


### PR DESCRIPTION
`pagination` prop might be empty for users or repo with few stargazers. 
Render methods should return an element, `null` or `false`.
