### PR TITLE
Change "watchers_count" to "subcribers_count"

### DIFF
--- a/lib/components/github/Repo.js
+++ b/lib/components/github/Repo.js
@@ -64,7 +64,7 @@ export default class Repo extends React.Component {
           </Link>
           <div className="repo-info">
             <p><i className="fa fa-star"></i> {repo.stargazers_count}</p>
-            <p><i className="fa fa-eye"></i> {repo.watchers_count}</p>
+            <p><i className="fa fa-eye"></i> {repo.subscribers_count}</p>
           </div>
         </div>
         <div>


### PR DESCRIPTION
This may be a bug in the Github API, since everywhere I see `watchers_count` it's identical to `stargazers_count`, which leads to duplicated numbers everywhere. However, `subscribers_count` is correct, at least on the main Repo endpoint.

I'm not sure why `subscribers_count` isn't in the API for the children repos, so those are still broken. I can update the PR if I find a way to get those in. If not, we can wait for Github to fix that :)
