### PR TITLE
Remove unnecessary function .bind()

### DIFF
--- a/lib/components/Application.js
+++ b/lib/components/Application.js
@@ -32,7 +32,7 @@ export default class Application extends React.Component {
       <div id="layout" className={activeClass}>
         <a href="#menu" id="menuLink"
           className={classnames('menu-link', activeClass)}
-          onClick={this.handleMenuClick.bind(this)}>
+          onClick={this.handleMenuClick}>
           <span></span>
         </a>
 


### PR DESCRIPTION
Was already bound [inside constructor](https://github.com/jayphelps/redux-react-router-async-example/blob/ba606603ffe558b0e6b7dd8b2b50e89a2f2382fa/lib/components/Application.js#L15)
