### PR TITLE
Make CSS hot reloadable

### DIFF
--- a/assets/stylesheets/index.css
+++ b/assets/stylesheets/index.css
@@ -7,6 +7,8 @@ html { box-sizing: border-box; }
 
 /* External CSS */
 @import "normalize.css/normalize.css";
+@import "purecss/build/pure-min.css";
+@import "purecss/build/grids-responsive-min.css";
 
 /* Global CSS */
 @import "page.css";

--- a/index.template.html
+++ b/index.template.html
@@ -9,13 +9,6 @@
     <link rel="shortcut icon" href="{%=o.htmlWebpackPlugin.files.favicon%}">
     {% } %}
 
-    <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.6.0/pure-min.css">
-    <!--[if lte IE 8]>
-    <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.6.0/grids-responsive-old-ie-min.css">
-    <![endif]-->
-    <!--[if gt IE 8]><!-->
-    <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.6.0/grids-responsive-min.css">
-    <!--<![endif]-->
     <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Raleway:200">
     <!--[if lt IE 9]>
       <script src="http://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7/html5shiv.js"></script>

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "history": "^1.12.5",
     "normalize.css": "^3.0.3",
     "parse-link-header": "^0.4.1",
+    "purecss": "0.6.0",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
     "react-intl": "2.0.0-pr-3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 var path = require('path');
 var webpack = require('webpack');
-var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
@@ -23,7 +22,6 @@ module.exports = {
       },
       '__DEVTOOLS__': process.env.DEVTOOLS === 'true' ? true : false
     }),
-    new ExtractTextPlugin('app.css', { allChunks: true }),
     new HtmlWebpackPlugin({
       title: 'Redux React Router Async Example',
       filename: 'index.html',
@@ -33,7 +31,7 @@ module.exports = {
   ],
   module: {
     loaders: [
-      { test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader!cssnext-loader') },
+      { test: /\.css$/, loader: 'style-loader!css-loader!cssnext-loader' },
       { test: /\.js$/, loaders: ['babel'], include: path.join(__dirname, 'lib') }
     ]
   },


### PR DESCRIPTION
For development we shouldn't use `ExtractTextPlugin` as it makes HMR unusable. Instead simply let webpack inject the style into HTML `head` and only on production extract css into a separate bundle.
