### PR TITLE
Correct nextPath for redirect after login

### DIFF
--- a/lib/components/pages/Login.js
+++ b/lib/components/pages/Login.js
@@ -28,7 +28,7 @@ export default class Login extends React.Component {
     const { history, store } = this.context
     const { location } = this.props
 
-    const nextPath = location.query.nextPathname || '/account'
+    const nextPath = location.state.nextPathname || '/account'
     store.dispatch(actions.login(this.state, () => {
       // redirect to a secure page
       history.pushState({}, nextPath)


### PR DESCRIPTION
This bug doesn't currently affect the behavior since the default nextPath after login is /account and the same path is the only Route using nextPathname through requireAuth in Root.js. But if you add requireAuth for another Route redirect will not be correct without this fix.
